### PR TITLE
added httpx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ streamlit==1.30
 stripe==6.5.0
 PyJWT==2.8.0
 openai==1.7.2
+httpx==0.24.1


### PR DESCRIPTION
I've added the package "httpx==0.24.1" for a possible socket_options keyword argument that is not expected in the initialization of the HTTPTransport object in the httpx library.